### PR TITLE
docs: Add paragraph to remove orphaned runners

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -82,3 +82,35 @@ ctr namespaces rm fireactions-2vcpu-4gb
 
 systemctl start containerd
 ```
+
+## How to clean up orphaned GH Runners?
+
+If there is a need to clean up GH Runners that have errored and didn't remove themselves, there is a one-line shell
+command that can remove all runners that are currently offline.
+
+Requirements:
+
+- The tools `jq`, `xargs` and the GitHub CLI
+- The GitHub CLI is authenticated as Organization Administrator for the affected Fireactions Pool.
+
+⚠️ **Warning**: This command will permanently delete runners. Ensure your organization depends on fireactions and that
+you have tested this in a non-production environment first. To preview which runners will be deleted without actually
+deleting them please omit the `xargs` step in the shell commands.
+
+To execute this command with bash, execute the following:
+
+```bash
+export GH_PAGER=
+export ORG="<ORG>"
+gh api --paginate /orgs/$ORG/actions/runners | jq '.runners[] | select(.status=="offline") | .id' | xargs -I {} gh api --method DELETE /orgs/$ORG/actions/runners/{}
+```
+
+To do the same with fish shell, execute the following:
+
+```fish
+set -x GH_PAGER
+set -x ORG <ORG>
+gh api --paginate /orgs/$ORG/actions/runners | jq '.runners[] | select(.status=="offline") | .id' | xargs -I {} gh api --method DELETE /orgs/$ORG/actions/runners/{}
+```
+
+Please replace `<ORG>` with the name of your GitHub Account or Organization.


### PR DESCRIPTION
## Description

This is a documentation-only PR that adds a paragraph to the troubleshooting section, explaining how to remove runners that are stuck inside the GitHub runner pool.

## Related Issue(s)

Fixes #260 

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting section showing one-line Bash and Fish commands (using gh, jq, xargs) to delete offline GitHub Runners, with prerequisites and a preview option.
  * The same troubleshooting content was inadvertently duplicated in the document, resulting in two identical sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->