### PR TITLE
feat: Support for github enterprise urls added (custom domains)

### DIFF
--- a/helper/github/client.go
+++ b/helper/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"crypto/tls"
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation"
@@ -10,26 +11,62 @@ import (
 // Client is a wrapper around GitHub client that supports GitHub App authentication for multiple installations.
 type Client struct {
 	*github.Client
-
-	transport *ghinstallation.AppsTransport
+	transport     *ghinstallation.AppsTransport
+	skipTLSVerify bool
 }
 
-// NewClient creates a new Client.
-func NewClient(appID int64, appPrivateKey string) (*Client, error) {
-	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, []byte(appPrivateKey))
+// NewClient creates a new GitHub App client that supports both GitHub.com and GitHub Enterprise API URLs.
+// githubEnterpriseApiUrl should be a full API base URL (e.g. https://api.githubenterprise.example.com/).
+func NewClient(appID int64, appPrivateKey string, githubEnterpriseApiUrl string, skipTLSVerify bool) (*Client, error) {
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	if skipTLSVerify {
+		if baseTransport.TLSClientConfig == nil {
+			baseTransport.TLSClientConfig = &tls.Config{}
+		}
+		baseTransport.TLSClientConfig.InsecureSkipVerify = true
+		// Prefer TLS 1.2+ even when skipping verification.
+		baseTransport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	}
+
+	transport, err := ghinstallation.NewAppsTransport(baseTransport, appID, []byte(appPrivateKey))
 	if err != nil {
 		return nil, err
 	}
 
-	client := &Client{
-		Client:    github.NewClient(&http.Client{Transport: transport}),
-		transport: transport,
+	httpClient := &http.Client{Transport: transport}
+	ghClient := github.NewClient(httpClient)
+
+	if githubEnterpriseApiUrl != "" {
+		ghClient, err = ghClient.WithEnterpriseURLs(githubEnterpriseApiUrl, "")
+		if err != nil {
+			return nil, err
+		}
+
+		transport.BaseURL = githubEnterpriseApiUrl
 	}
 
-	return client, nil
+	return &Client{
+		Client:        ghClient,
+		transport:     transport,
+		skipTLSVerify: skipTLSVerify,
+	}, nil
 }
 
-// Installation returns a new GitHub client for the given installation ID.
 func (c *Client) Installation(installationID int64) *github.Client {
-	return github.NewClient(&http.Client{Transport: ghinstallation.NewFromAppsTransport(c.transport, installationID)})
+	installationTransport := ghinstallation.NewFromAppsTransport(c.transport, installationID)
+	httpClient := &http.Client{Transport: installationTransport}
+
+	installationClient := github.NewClient(httpClient)
+
+	// Detect if we're using GitHub Enterprise (since DefaultBaseURL is no longer exported)
+	if c.Client.BaseURL != nil && c.Client.BaseURL.String() != "https://api.github.com/" {
+		if enterpriseClient, err := installationClient.WithEnterpriseURLs(
+			c.Client.BaseURL.String(),
+			c.Client.UploadURL.String(),
+		); err == nil {
+			return enterpriseClient
+		}
+	}
+
+	return installationClient
 }

--- a/helper/github/client_test.go
+++ b/helper/github/client_test.go
@@ -7,19 +7,67 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewClient_Success(t *testing.T) {
+func TestNewClient_Success_GitHubCom(t *testing.T) {
 	key, err := os.ReadFile("testdata/test.key")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	client, err := NewClient(12345, string(key))
+	client, err := NewClient(12345, string(key), "", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.NotNil(t, client.Client)
+	assert.NotNil(t, client.transport)
+
+	// Should default to GitHub.com
+	assert.Contains(t, client.Client.BaseURL.String(), "https://api.github.com/")
+}
+
+func TestNewClient_Success_GitHubCom_TLS(t *testing.T) {
+	key, err := os.ReadFile("testdata/test.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := NewClient(12345, string(key), "", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 }
 
+func TestNewClient_Success_Enterprise(t *testing.T) {
+	key, err := os.ReadFile("testdata/test.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakeEnterpriseURL := "https://api.githubenterprise.example.com/"
+
+	client, err := NewClient(12345, string(key), fakeEnterpriseURL, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.NotNil(t, client.transport)
+
+	// Ensure the Enterprise base URL was applied
+	assert.Contains(t, client.Client.BaseURL.String(), fakeEnterpriseURL)
+	assert.Equal(t, client.transport.BaseURL, fakeEnterpriseURL)
+}
+
+func TestNewClient_Success_Enterprise_TLS(t *testing.T) {
+	key, err := os.ReadFile("testdata/test.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakeEnterpriseURL := "https://api.githubenterprise.example.com/"
+
+	client, err := NewClient(12345, string(key), fakeEnterpriseURL, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Contains(t, client.Client.BaseURL.String(), fakeEnterpriseURL)
+}
+
 func TestNewClient_Failure(t *testing.T) {
-	client, err := NewClient(12345, "")
+	client, err := NewClient(12345, "", "", false)
 	assert.Error(t, err)
 	assert.Nil(t, client)
 }
@@ -30,9 +78,32 @@ func TestClientInstallation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, err := NewClient(12345, string(key))
+	client, err := NewClient(12345, string(key), "", false)
 	assert.NoError(t, err)
+	assert.NotNil(t, client)
 
 	installation := client.Installation(12345)
 	assert.NotNil(t, installation)
+
+	// The installation client should still have a valid BaseURL
+	assert.Contains(t, installation.BaseURL.String(), "https://api.github.com/")
+}
+
+func TestClientInstallation_Enterprise(t *testing.T) {
+	key, err := os.ReadFile("testdata/test.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakeEnterpriseURL := "https://api.githubenterprise.example.com/"
+
+	client, err := NewClient(12345, string(key), fakeEnterpriseURL, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	installation := client.Installation(12345)
+	assert.NotNil(t, installation)
+
+	// Should retain enterprise base URL
+	assert.Contains(t, installation.BaseURL.String(), fakeEnterpriseURL)
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -9,8 +9,15 @@ import (
 func TestNewConfig(t *testing.T) {
 	config, err := NewConfig("testdata/config1.yaml")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	assert.Equal(t, "testdata/config1.yaml", config.path)
+
+	// Check GitHub config values
+	assert.NotNil(t, config.GitHub)
+	assert.NotEmpty(t, config.GitHub.AppPrivateKey)
+	assert.NotZero(t, config.GitHub.AppID)
+	assert.Equal(t, "https://api.githubenterprise.example.com/api/v3", config.GitHub.EnterpriseApiUrl)
+	assert.True(t, config.GitHub.SkipTLSVerify)
 }

--- a/server/testdata/config1.yaml
+++ b/server/testdata/config1.yaml
@@ -16,51 +16,53 @@ github:
   app_private_key: |
     -----BEGIN RSA PRIVATE KEY-----
   app_id: 12345
+  enterprise_api_url: "https://api.githubenterprise.example.com/api/v3" # optional, empty = github.com, otherwise i.e. https://example.com/api/v3, or https://api.example.com
+  skip_tls_verify: true
 
 pools:
-- name: fireactions-2vcpu-2gb
-  max_runners: 20
-  min_runners: 10
-  runner:
-    name: fireactions-2vcpu-2gb
-    image: ghcr.io/hostinger/fireactions/runner:ubuntu-20.04-x64-2.310.2
-    image_pull_policy: IfNotPresent
-    group_id: 1
-    organization: hostinger
-    labels:
-    - self-hosted
-    - fireactions-2vcpu-2gb
-    - fireactions
-  firecracker:
-    binary_path: firecracker
-    kernel_image_path: /var/lib/fireactions/vmlinux
-    kernel_args: "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
-    machine_config:
-      mem_size_mib: 2048
-      vcpu_count: 2
-    metadata:
-      example1: value1
-- name: fireactions-2vcpu-4gb
-  max_runners: 20
-  min_runners: 10
-  runner:
-    name: fireactions-2vcpu-4gb
-    image: ghcr.io/hostinger/fireactions/runner:ubuntu-20.04-x64-2.310.2
-    image_pull_policy: IfNotPresent
-    group_id: 1
-    organization: hostinger
-    labels:
-    - self-hosted
-    - fireactions-2vcpu-2gb
-    - fireactions
-  firecracker:
-    binary_path: firecracker
-    kernel_image_path: /var/lib/fireactions/vmlinux
-    kernel_args: "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
-    machine_config:
-      mem_size_mib: 4096
-      vcpu_count: 2
-    metadata:
-      example1: value1
+  - name: fireactions-2vcpu-2gb
+    max_runners: 20
+    min_runners: 10
+    runner:
+      name: fireactions-2vcpu-2gb
+      image: ghcr.io/hostinger/fireactions/runner:ubuntu-20.04-x64-2.310.2
+      image_pull_policy: IfNotPresent
+      group_id: 1
+      organization: hostinger
+      labels:
+        - self-hosted
+        - fireactions-2vcpu-2gb
+        - fireactions
+    firecracker:
+      binary_path: firecracker
+      kernel_image_path: /var/lib/fireactions/vmlinux
+      kernel_args: "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
+      machine_config:
+        mem_size_mib: 2048
+        vcpu_count: 2
+      metadata:
+        example1: value1
+  - name: fireactions-2vcpu-4gb
+    max_runners: 20
+    min_runners: 10
+    runner:
+      name: fireactions-2vcpu-4gb
+      image: ghcr.io/hostinger/fireactions/runner:ubuntu-20.04-x64-2.310.2
+      image_pull_policy: IfNotPresent
+      group_id: 1
+      organization: hostinger
+      labels:
+        - self-hosted
+        - fireactions-2vcpu-2gb
+        - fireactions
+    firecracker:
+      binary_path: firecracker
+      kernel_image_path: /var/lib/fireactions/vmlinux
+      kernel_args: "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
+      machine_config:
+        mem_size_mib: 4096
+        vcpu_count: 2
+      metadata:
+        example1: value1
 
 log_level: debug


### PR DESCRIPTION
By default github.com is being used to register the runners, we have certain cases where github enterprise is used with a custom domain.

- Option added in the config to provide custom enterprise urls
- Ability added to skip tls verification in case of self signed certificates

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
<!--- Please link to the issue(s) here: -->
https://github.com/hostinger/fireactions/issues/272
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Enterprise support with optional TLS verification bypass.
  * Live configuration reload via a public Reload API.

* **Configuration**
  * New options: enterprise API URL and skip TLS verification (CLI flags/env).
  * Pools now defined as a list of pool objects.
  * Validation: TLS bypass allowed only when an enterprise API URL is set; image pull policy is now case-sensitive.

* **Tests**
  * Expanded tests covering GitHub.com and Enterprise TLS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->